### PR TITLE
Set iOS 9 as min deployment target

### DIFF
--- a/ContextMenu.podspec
+++ b/ContextMenu.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |spec|
   spec.name         = 'ContextMenu'
-  spec.version      = '0.3.0'
+  spec.version      = '0.3.1'
   spec.license      = { :type => 'MIT' }
   spec.homepage     = 'https://github.com/GitHawkApp/ContextMenu'
   spec.authors      = { 'Ryan Nystrom' => 'rnystrom@whoisryannystrom.com' }
   spec.summary      = 'Context menu inspired by Things 3.'
   spec.source       = { :git => 'https://github.com/GitHawkApp/ContextMenu.git', :tag => spec.version.to_s }
   spec.source_files = 'ContextMenu/*.swift'
-  spec.platform     = :ios, '10.0'
+  spec.platform     = :ios, '9.0'
   spec.swift_version = '4.0'
 end

--- a/ContextMenu.xcodeproj/project.pbxproj
+++ b/ContextMenu.xcodeproj/project.pbxproj
@@ -417,6 +417,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = ContextMenu/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.whoisryannystrom.ContextMenu;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -440,6 +441,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = ContextMenu/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.whoisryannystrom.ContextMenu;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";

--- a/ContextMenu.xcodeproj/project.pbxproj
+++ b/ContextMenu.xcodeproj/project.pbxproj
@@ -408,10 +408,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 523C4DWBTH;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -421,6 +421,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.whoisryannystrom.ContextMenu;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 4.0;
@@ -432,10 +433,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
-				DEVELOPMENT_TEAM = 523C4DWBTH;
+				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -445,6 +446,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.whoisryannystrom.ContextMenu;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/ContextMenu/ContextMenu.swift
+++ b/ContextMenu/ContextMenu.swift
@@ -37,7 +37,7 @@ public class ContextMenu: NSObject {
             previous.viewController.dismiss(animated: false)
         }
 
-        if let style = options.hapticsStyle {
+        if #available(iOS 10, *), let style = options.hapticsStyle {
             let haptics = UIImpactFeedbackGenerator(style: style)
             haptics.impactOccurred()
         }


### PR DESCRIPTION
Seems like nothing stops us from decreasing the minimum deployment target. It has a little bug though — the navigation bar of the presented view jumps on appear. For now we didn't need the bar, so it works, whatever I'll try to investigate it later.