### PR TITLE
[#44] Add API to disable tap-to-dismiss

### DIFF
--- a/ContextMenu/ContextMenu.swift
+++ b/ContextMenu/ContextMenu.swift
@@ -15,6 +15,16 @@ public class ContextMenu: NSObject {
     public static let shared = ContextMenu()
 
     var item: Item?
+    
+    public var delegate: ContextMenuDelegate? {
+        get {
+            self.item?.delegate
+        }
+        
+        set {
+            self.item?.delegate = newValue
+        }
+    }
 
     private override init() {}
 
@@ -54,6 +64,15 @@ public class ContextMenu: NSObject {
         item.viewController.modalPresentationStyle = .custom
         item.viewController.modalPresentationCapturesStatusBarAppearance = true
         sourceViewController.present(item.viewController, animated: true)
+    }
+    
+    /// Dismiss current showing context menu.
+    ///
+    /// - Parameters:
+    ///   - animated: Animated the transition.
+    ///   - completion: The block to execute after the view controller is dismissed.
+    public func dismiss(animated: Bool = true, completion: (() -> Void)? = nil) {
+        self.item?.viewController.dismiss(animated: animated, completion: completion)
     }
 
 }

--- a/ContextMenu/ContextMenuDelegate.swift
+++ b/ContextMenu/ContextMenuDelegate.swift
@@ -9,6 +9,7 @@
 import UIKit
 
 public protocol ContextMenuDelegate: class {
+    func contextMenuAllowTapToClose() -> Bool
     func contextMenuWillDismiss(viewController: UIViewController, animated: Bool)
     func contextMenuDidDismiss(viewController: UIViewController, animated: Bool)
 }

--- a/ContextMenu/ContextMenuPresentationController.swift
+++ b/ContextMenu/ContextMenuPresentationController.swift
@@ -170,6 +170,10 @@ class ContextMenuPresentationController: UIPresentationController {
     }
 
     @objc func onTap(recognizer: UITapGestureRecognizer) {
+        if let delegate = item.delegate, delegate.contextMenuAllowTapToClose() == false {
+            return
+        }
+        
         guard recognizer.state == .ended,
             let containerView = self.containerView,
             presentedView?.frame.contains(recognizer.location(in: containerView)) == false


### PR DESCRIPTION
Hi @rnystrom, this PR implement the #44.

* Add a delegate method to check allow tap to dismiss. (If no delegate, default can be tap dismiss)
* Add a `delegate` property for some use case, for example, when wrapped the delegate pattern to `Delegate Proxy` with RxSwift.

If there have any suggestions or concerns, please let me know. 😃 Thanks.